### PR TITLE
Broken System test

### DIFF
--- a/test/test_sys.cpp
+++ b/test/test_sys.cpp
@@ -4,7 +4,6 @@
 
 BOOST_AUTO_TEST_SUITE(system_suite)
 
-#if defined(_WIN32)
 
 BOOST_AUTO_TEST_CASE(win_test)
 {
@@ -12,20 +11,15 @@ BOOST_AUTO_TEST_CASE(win_test)
     BOOST_REQUIRE(BOOST_IS_DEFINED(_WIN32));
 }
 
-#else
-
 BOOST_AUTO_TEST_CASE(sys_test)
 {
     BOOST_WARN_MESSAGE(BOOST_IS_DEFINED(__unix__), "System is not linux");
     BOOST_REQUIRE(!BOOST_IS_DEFINED(_WIN32));
 }
 
-#endif
-
-
 BOOST_AUTO_TEST_CASE(gen_test)
 {
-    BOOST_CHECK_MESSAGE(true, "some test would be here");
+    BOOST_CHECK_MESSAGE(false, "some test would be here");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
To demonstrate one use-case for report.ci, this PR shows different broken tests, depending on the operating system.